### PR TITLE
add trailing commas to fix runtime err

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ require("eza-preview"):setup({
   level = 3,
 
   -- Whether to follow symlinks when previewing directories (default: false)
-  follow_symlinks = false
+  follow_symlinks = false,
 
   -- Whether to show target file info instead of symlink info (default: false)
-  dereference = false
+  dereference = false,
 })
 
 -- Or use default settings with empty table


### PR DESCRIPTION
# Error
Error: Lua runtime failed

Caused by:
    syntax error: [string "init.lua"]:9: '}' expected (to close '{' at line 1) near 'dereference
    
# Solution
Adding trailing commas    